### PR TITLE
Add refresh token functionnality with cookies 'fingerprint' and 'refresh'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 PORT=3001
-TOKEN_SECRET=your_secret_key_here
+TOKEN_SECRET=your_secret_key_here_at_least_32_random_characters
 PG_URL=postgres://user:MDP@localhost:5432/dbname
 CORS_ORIGIN=*
 TMDB_API_KEY=
 NODE_ENV=production
 USE_REDIS_CACHE=true
-REDIS_URL="redis-16260.c135.eu-central-1-1.ec2.redns.redis-cloud.com"
+REDIS_URL=******.redis-cloud.com
 REDIS_PORT=16260
-REDIS_PASSWORD="6LhB20N5xxNbmY3UmMFNtIxqBi9ytVww"
+REDIS_PASSWORD=********
 EMAIL_USER=omovies374@gmail.com
 EMAIL_PASS=your-email-password

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     {
       "env": {
         "node": true,
-        "es6": true
+        "es6": true,
       },
       "files": [".eslintrc.{js,cjs}"],
       "parserOptions": {
@@ -23,9 +23,5 @@ module.exports = {
   "globals": {
     "process": "readonly",
   },
-  "rules": {
-    "indent": ["error", 2],
-    "quotes": ["error", "double"],
-    "semi": ["error", "always"],
-  },
+  "rules": {},
 };

--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -2,6 +2,7 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import ApiError from "../errors/ApiError.js";
 import { User } from "../models/User.js";
+import { generateTokens, hashToken, setCookies } from "../utils/auth.js";
 
 const authController = {
   async registerUser(req, res, next) {
@@ -41,7 +42,9 @@ const authController = {
       return next(new ApiError(401, "Account not found"));
     }
     // create a token
-    const token = jwt.sign({ id: user.id }, process.env.TOKEN_SECRET, { expiresIn: "30d" });
+    const { token, fingerprint, refresh } = generateTokens(user.id);
+    // add cookies with the fingerprint and refresh token
+    setCookies(req, res, fingerprint, refresh);
     // create the data user
     const dataUser = {
       firstname: user.firstname,
@@ -52,6 +55,24 @@ const authController = {
     // return the user
     return res.json({ status: "success", data: dataUser });
   },
+
+  async refreshToken(req, res, next) {
+    // token has not been checked in verifyToken middleware because it's probably expired
+    const refresh = req.cookies["refresh"] || undefined;
+    const JWTtoken = req.headers["authorization"]?.slice(7) || undefined;
+    const decoded = (JWTtoken && jwt.decode(JWTtoken, process.env.TOKEN_SECRET)) || undefined;
+    // check if the JWT token and the refresh cookie exist and are valid
+    if (!refresh || !decoded || hashToken(refresh) !== decoded.refresh) {
+      return next(new ApiError(401, "Refresh token not found or invalid, user has to login again"));
+    }
+    // req.userId is set in optionalToken middleware
+    const { token: newToken, fingerprint, refresh: newRefresh } = generateTokens(req.userId);
+    // update cookies with the fingerprint and refresh token
+    setCookies(req, res, fingerprint, newRefresh);
+    // return the new token
+    return res.json({ status: "success", data: { token: newToken } });
+  },
+
   async changePassword(req, res, next) {
     const { oldPassword, newPassword } = req.body;
     const user = await User.findByPk(req.userId);

--- a/app/controllers/authController.js
+++ b/app/controllers/authController.js
@@ -66,7 +66,7 @@ const authController = {
       return next(new ApiError(401, "Refresh token not found or invalid, user has to login again"));
     }
     // req.userId is set in optionalToken middleware
-    const { token: newToken, fingerprint, refresh: newRefresh } = generateTokens(req.userId);
+    const { token: newToken, fingerprint, refresh: newRefresh } = generateTokens(decoded.id);
     // update cookies with the fingerprint and refresh token
     setCookies(req, res, fingerprint, newRefresh);
     // return the new token

--- a/app/index.app.js
+++ b/app/index.app.js
@@ -1,20 +1,21 @@
+import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
-import router from "./routers/index.router.js";
-import { initSwagger } from "./services/swagger.js";
 import errorMiddleware from "./middlewares/errorMiddleware.js";
 import rateLimiter from "./middlewares/rateLimiteMiddleware.js";
 import bodySanitizer from "./middlewares/sanitizeMiddleware.js";
+import router from "./routers/index.router.js";
+import { initSwagger } from "./services/swagger.js";
 
 const app = express();
 // Initilise Swagger
 initSwagger(app);
 // autorise cors from the env variable
-app.use(cors({ origin: process.env.CORS_ORIGIN }));
-//parse json and urlencoded data
+app.use(cors({ origin: process.env.CORS_ORIGIN, credentials: true, maxAge: 600 }));
+//parse json and urlencoded data and cookies
 app.use(express.json());
-
 app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
 // rate limiter middleware to limit the number of request to the api check the rateLimiter middleware
 app.use(rateLimiter);
 // sanitize the request body check the bodySanitizer middleware

--- a/app/middlewares/authMiddleware.js
+++ b/app/middlewares/authMiddleware.js
@@ -1,21 +1,58 @@
 import jwt from "jsonwebtoken";
 import ApiError from "../errors/ApiError.js";
+import { hashToken } from "../utils/auth.js";
 
-function verifyToken (req, res, next) {
-  const token = req.headers["authorization"]?.slice(7); // get the token from the header
-  if (!token) {
-    return next (new ApiError(403,"No token provided!" )); // if there isn't any token
-  }
+async function verifyToken(req, _, next) {
   try {
+    const token = req.headers["authorization"]?.slice(7);
+    const fingerprint = req.cookies?.fingerprint;
+    if (!token || !fingerprint) {
+      return next(new ApiError(401, "No token or fingerprint provided!"));
+    }
     const decoded = jwt.verify(token, process.env.TOKEN_SECRET); // verify token
+    const hashedFingerprint = hashToken(fingerprint);
+    if (decoded.fingerprint !== hashedFingerprint) {
+      return next(new ApiError(401, "Invalid fingerprint"));
+    }
     req.userId = decoded.id; // add the user id to the request
     next();
-  } catch (error){
-    if (error) {
-      console.error(error);
-      return next(new ApiError(401,"Unauthorized!" ));
+  } catch (error) {
+    console.error(error);
+    if (error instanceof jwt.JsonWebTokenError) {
+      return next(new ApiError(401, "Invalid token"));
+    } else if (error instanceof jwt.TokenExpiredError) {
+      return next(new ApiError(401, "Token expired"));
+    } else {
+      return next(new ApiError(500, "Internal server error"));
     }
   }
 }
 
-export default verifyToken;
+async function optionalToken(req, _, next) {
+  try {
+    const token = req.headers["authorization"]?.slice(7);
+    const fingerprint = req.cookies?.fingerprint;
+    if (!token || !fingerprint) {
+      console.log("No token or fingerprint provided!");
+      return next(); // If there's no token or fingerprint, just move on.
+    }
+    const decoded = jwt.decode(token, process.env.TOKEN_SECRET); // verify token
+    const hashedFingerprint = hashToken(fingerprint);
+    if (decoded.fingerprint !== hashedFingerprint) {
+      console.log("Invalid fingerprint");
+      return next(); // Invalid fingerprint, move on without error
+    }
+    req.userId = decoded.id; // add the user id to the request
+  } catch (error) {
+    // console.error(error);
+    // Handle specific JWT errors but do not throw them
+    if (error instanceof jwt.JsonWebTokenError || error instanceof jwt.TokenExpiredError) {
+      console.log("Invalid or expired token");
+      return next(); // Invalid token, move on without setting userId
+    }
+  }
+
+  next();
+}
+
+export { optionalToken, verifyToken };

--- a/app/middlewares/controllerWrapper.js
+++ b/app/middlewares/controllerWrapper.js
@@ -3,6 +3,7 @@ export default (controller) => async (req, res, next) => {
   try {
     await controller(req, res, next);
   } catch (error) {
+    console.log(error);
     next(error);
   }
 };

--- a/app/middlewares/errorMiddleware.js
+++ b/app/middlewares/errorMiddleware.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 export default (err, req, res, next) => {
   let { status, message } = err;
-  const { code } = err;   
+  const { code } = err;
   if (code === "23505") {
     status = 400;
     message = "Resource already exists";
@@ -9,8 +9,8 @@ export default (err, req, res, next) => {
   if (!status) {
     status = 500;
   }
-  if (status === 500) {   
-    console.error(err); 
+  if (status === 500) {
+    console.error(err);
     message = "Internal Server Error";
   }
   if (res.format === "html") {
@@ -25,5 +25,5 @@ export default (err, req, res, next) => {
     message = "Token expired";
   }
   // return the error message in json format
-  return res.status(status).json({status :"fail", error: message });  
+  return res.status(status).json({ status: "fail", error: message });
 };

--- a/app/routers/api/auth.router.js
+++ b/app/routers/api/auth.router.js
@@ -1,6 +1,6 @@
 import express from "express";
 import authController from "../../controllers/authController.js";
-import { optionalToken, verifyToken } from "../../middlewares/authMiddleware.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
 import userSchema from "../../validation/userSchemas.js";
@@ -68,7 +68,7 @@ router.post(
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("/refresh-token", optionalToken, controllerWrapper(authController.refreshToken));
+router.post("/refresh-token", controllerWrapper(authController.refreshToken));
 
 /**
  * POST /api/auth/change/password

--- a/app/routers/api/auth.router.js
+++ b/app/routers/api/auth.router.js
@@ -1,21 +1,21 @@
 import express from "express";
 import authController from "../../controllers/authController.js";
+import { optionalToken, verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
 import userSchema from "../../validation/userSchemas.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
 
 const router = express.Router();
 
 /**
- * A user object 
+ * A user object
  * @typedef {object} UserLogin
  * @property {string} email - The user email
  * @property {string} password - The user password
  */
 
 /**
- * A user object 
+ * A user object
  * @typedef {object} UserRegister
  * @property {string} email - The user email
  * @property {string} password - The user password
@@ -39,8 +39,11 @@ const router = express.Router();
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("/login", validationMiddleware({ body: userSchema.signInSchema }), 
-  controllerWrapper(authController.loginUser));
+router.post(
+  "/login",
+  validationMiddleware({ body: userSchema.signInSchema }),
+  controllerWrapper(authController.loginUser)
+);
 
 /**
  * POST /api/auth/register
@@ -51,8 +54,21 @@ router.post("/login", validationMiddleware({ body: userSchema.signInSchema }),
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("/register", validationMiddleware({ body: userSchema.registerSchema }), 
-  controllerWrapper(authController.registerUser));
+router.post(
+  "/register",
+  validationMiddleware({ body: userSchema.registerSchema }),
+  controllerWrapper(authController.registerUser)
+);
+
+/**
+ * POST /api/auth/refresh-token
+ * @summary Refresh the access token of the user
+ * @tags Auth
+ * @return {ApiSuccess} 200 - success response
+ * @return {ApiError} 400 - bad input response
+ * @return {ApiError} 500 - internal server error response
+ */
+router.post("/refresh-token", optionalToken, controllerWrapper(authController.refreshToken));
 
 /**
  * POST /api/auth/change/password
@@ -63,7 +79,11 @@ router.post("/register", validationMiddleware({ body: userSchema.registerSchema 
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("/change/password", verifyToken, validationMiddleware({ body: userSchema.changePasswordSchema }),
-  controllerWrapper(authController.changePassword));
+router.post(
+  "/change/password",
+  verifyToken,
+  validationMiddleware({ body: userSchema.changePasswordSchema }),
+  controllerWrapper(authController.changePassword)
+);
 
 export default router;

--- a/app/routers/api/movies.router.js
+++ b/app/routers/api/movies.router.js
@@ -1,9 +1,10 @@
 import express from "express";
 import moviesController from "../../controllers/moviesController.js";
+import { optionalToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
-import movieSchema from "../../validation/movieSchemas.js";
 import genericSchema from "../../validation/genericSchemas.js";
+import movieSchema from "../../validation/movieSchemas.js";
 
 const router = express.Router();
 
@@ -24,8 +25,6 @@ const router = express.Router();
  * @property {string} crew - The movie crew
  */
 
-
-
 /**
  * GET /api/movie/genre
  * @summary Get movie genres
@@ -45,8 +44,11 @@ router.get("/genre", controllerWrapper(moviesController.getMovieGenres));
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.get("/search", validationMiddleware({ query: movieSchema.getMovieSearch }),
-  controllerWrapper(moviesController.getMovieBySearch));
+router.get(
+  "/search",
+  validationMiddleware({ query: movieSchema.getMovieSearch }),
+  controllerWrapper(moviesController.getMovieBySearch)
+);
 
 /**
  * GET /api/movie/upcoming
@@ -97,11 +99,15 @@ router.get("/toprated", controllerWrapper(moviesController.getTopRatedMovies));
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.get("/:id", validationMiddleware({ params: genericSchema.paramsId }),
-  controllerWrapper(moviesController.getMoviesById));
+router.get(
+  "/:id",
+  optionalToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(moviesController.getMovieById)
+);
 
 /**
- * GET /api/movie 
+ * GET /api/movie
  * @summary Get movies with parameters
  * @tags Movies
  * @param {string} sort_by.query - Sorting criteria
@@ -116,8 +122,11 @@ router.get("/:id", validationMiddleware({ params: genericSchema.paramsId }),
  * @return {Array<Movie>} 200 - success response
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
- */ 
-router.get("", validationMiddleware({ query: movieSchema.getMoviesWithQueries }),
-  controllerWrapper(moviesController.getMovies));
+ */
+router.get(
+  "",
+  validationMiddleware({ query: movieSchema.getMoviesWithQueries }),
+  controllerWrapper(moviesController.getMovies)
+);
 
 export default router;

--- a/app/routers/api/playlists.router.js
+++ b/app/routers/api/playlists.router.js
@@ -1,10 +1,10 @@
 import express from "express";
 import playlistController from "../../controllers/playlistController.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
-import playlistSchema from "../../validation/playlistSchemas.js";
 import genericSchema from "../../validation/genericSchemas.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
+import playlistSchema from "../../validation/playlistSchemas.js";
 
 const router = express.Router();
 
@@ -30,14 +30,14 @@ const router = express.Router();
  * @property {number} tmdb_id - The tmdb id
  */
 
-/** 
+/**
  * GET /api/playlist
  * @summary Get playlists
  * @tags Playlist
  * @return {Array<Playlist>} 200 - success response
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
- * 
+ *
  */
 router.get("", verifyToken, controllerWrapper(playlistController.getPlaylists));
 
@@ -50,8 +50,12 @@ router.get("", verifyToken, controllerWrapper(playlistController.getPlaylists));
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("", verifyToken, validationMiddleware({ body: playlistSchema.playlistSchema }), 
-  controllerWrapper(playlistController.createPlaylist));
+router.post(
+  "",
+  verifyToken,
+  validationMiddleware({ body: playlistSchema.playlistSchema }),
+  controllerWrapper(playlistController.createPlaylist)
+);
 
 /**
  * GET /api/playlist/:id
@@ -62,8 +66,12 @@ router.post("", verifyToken, validationMiddleware({ body: playlistSchema.playlis
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.get("/:id", verifyToken, validationMiddleware({ params: genericSchema.paramsId }), 
-  controllerWrapper(playlistController.getPlaylistById));
+router.get(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(playlistController.getPlaylistById)
+);
 
 /**
  * PATCH /api/playlist/:id
@@ -75,8 +83,12 @@ router.get("/:id", verifyToken, validationMiddleware({ params: genericSchema.par
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.patch("/:id", verifyToken, validationMiddleware({ body: playlistSchema.playlistSchema, params: genericSchema.paramsId }), 
-  controllerWrapper(playlistController.updatePlaylist));
+router.patch(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ body: playlistSchema.playlistSchema, params: genericSchema.paramsId }),
+  controllerWrapper(playlistController.updatePlaylist)
+);
 
 /**
  * DELETE /api/playlist/:id
@@ -87,8 +99,12 @@ router.patch("/:id", verifyToken, validationMiddleware({ body: playlistSchema.pl
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.delete("/:id", verifyToken, validationMiddleware({ params: genericSchema.paramsId }), 
-  controllerWrapper(playlistController.deletePlaylist));
+router.delete(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(playlistController.deletePlaylist)
+);
 
 /**
  * POST /api/playlist/:id/addmovie
@@ -100,8 +116,12 @@ router.delete("/:id", verifyToken, validationMiddleware({ params: genericSchema.
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("/:id/addmovie", verifyToken, validationMiddleware({ body: playlistSchema.movieSchema, params: genericSchema.paramsId }), 
-  controllerWrapper(playlistController.addMovieInPlayist));
+router.post(
+  "/:id/addmovie",
+  verifyToken,
+  validationMiddleware({ body: playlistSchema.movieSchema, params: genericSchema.paramsId }),
+  controllerWrapper(playlistController.addMovieInPlayist)
+);
 
 /**
  * DELETE /api/playlist/:id/deletemovie
@@ -113,7 +133,11 @@ router.post("/:id/addmovie", verifyToken, validationMiddleware({ body: playlistS
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.delete("/:id/deletemovie/:tmdb_id", verifyToken, validationMiddleware({params: genericSchema.paramsId }), 
-  controllerWrapper(playlistController.deleteMovieInPlaylist));
+router.delete(
+  "/:id/deletemovie/:tmdb_id",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(playlistController.deleteMovieInPlaylist)
+);
 
 export default router;

--- a/app/routers/api/profil.router.js
+++ b/app/routers/api/profil.router.js
@@ -1,12 +1,12 @@
 import express from "express";
 import profilController from "../../controllers/profilController.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
 
 const router = express.Router();
 
 /**
- * A user object 
+ * A user object
  * @typedef {object} User
  * @property {number} id - The user token
  * @property {string} firstname - The user firstname

--- a/app/routers/api/ratings.router.js
+++ b/app/routers/api/ratings.router.js
@@ -1,10 +1,10 @@
 import express from "express";
 import ratingsController from "../../controllers/ratingsController.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
-import ratingSchema from "../../validation/ratingSchemas.js";
 import genericSchema from "../../validation/genericSchemas.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
+import ratingSchema from "../../validation/ratingSchemas.js";
 
 const router = express.Router();
 
@@ -29,8 +29,12 @@ const router = express.Router();
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("", verifyToken, validationMiddleware({ body: ratingSchema.createRatingSchema }),
-  controllerWrapper(ratingsController.createRating));
+router.post(
+  "",
+  verifyToken,
+  validationMiddleware({ body: ratingSchema.createRatingSchema }),
+  controllerWrapper(ratingsController.createRating)
+);
 
 /**
  * PATCH /api/rating/:id
@@ -42,8 +46,12 @@ router.post("", verifyToken, validationMiddleware({ body: ratingSchema.createRat
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.patch("/:id", verifyToken, validationMiddleware({ body: ratingSchema.updateRatingSchema, params: genericSchema.paramsId }),
-  controllerWrapper(ratingsController.updateRating));
+router.patch(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ body: ratingSchema.updateRatingSchema, params: genericSchema.paramsId }),
+  controllerWrapper(ratingsController.updateRating)
+);
 
 /**
  * DELETE /api/rating/:id
@@ -54,7 +62,11 @@ router.patch("/:id", verifyToken, validationMiddleware({ body: ratingSchema.upda
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.delete("/:id", verifyToken, validationMiddleware({ params: genericSchema.paramsId }),
-  controllerWrapper(ratingsController.deleteRating));
+router.delete(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(ratingsController.deleteRating)
+);
 
 export default router;

--- a/app/routers/api/reviews.router.js
+++ b/app/routers/api/reviews.router.js
@@ -1,10 +1,10 @@
 import express from "express";
 import reviewsController from "../../controllers/reviewsController.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
-import reviewSchema from "../../validation/reviewSchemas.js";
 import genericSchema from "../../validation/genericSchemas.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
+import reviewSchema from "../../validation/reviewSchemas.js";
 
 const router = express.Router();
 
@@ -23,8 +23,12 @@ const router = express.Router();
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.post("", verifyToken, validationMiddleware({ body: reviewSchema.createReviewSchema }),
-  controllerWrapper(reviewsController.createReview));
+router.post(
+  "",
+  verifyToken,
+  validationMiddleware({ body: reviewSchema.createReviewSchema }),
+  controllerWrapper(reviewsController.createReview)
+);
 
 /**
  * PATCH /api/review/:id
@@ -36,10 +40,14 @@ router.post("", verifyToken, validationMiddleware({ body: reviewSchema.createRev
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */
-router.patch("/:id", verifyToken, validationMiddleware({ body: reviewSchema.updateReviewSchema, params: genericSchema.paramsId }),
-  controllerWrapper(reviewsController.updateReview));
+router.patch(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ body: reviewSchema.updateReviewSchema, params: genericSchema.paramsId }),
+  controllerWrapper(reviewsController.updateReview)
+);
 
-/** 
+/**
  * DELETE /api/review/:id
  * @summary Delete a review
  * @tags Reviews
@@ -47,8 +55,12 @@ router.patch("/:id", verifyToken, validationMiddleware({ body: reviewSchema.upda
  * @return {ApiSuccess} 200 - success response
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
-*/
-router.delete("/:id", verifyToken, validationMiddleware({ params: genericSchema.paramsId }),
-  controllerWrapper(reviewsController.deleteReview));
+ */
+router.delete(
+  "/:id",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(reviewsController.deleteReview)
+);
 
 export default router;

--- a/app/routers/api/views.router.js
+++ b/app/routers/api/views.router.js
@@ -1,6 +1,6 @@
 import express from "express";
 import viewsController from "../../controllers/viewsController.js";
-import verifyToken from "../../middlewares/authMiddleware.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
 import viewSchemas from "../../validation/viewSchemas.js";

--- a/app/utils/auth.js
+++ b/app/utils/auth.js
@@ -1,0 +1,44 @@
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
+
+function hashToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function setCookies(req, res, fingerprint, refresh) {
+  // fingerprint is used in pair with jwt token to securely identify the user (see OWASP recommendation)
+  res.cookie("fingerprint", fingerprint, {
+    httpOnly: true,
+    secure: true,
+    // sameSite: "Strict",
+    maxAge: 1000 * 60 * 15, // 15 minutes (same as JWT token)
+  });
+  // refresh token is used to get a new jwt token
+  res.cookie("refresh", refresh, {
+    httpOnly: true,
+    secure: true,
+    // sameSite: "Strict",
+    maxAge: 1000 * 60 * 60 * 24 * 1, // 1 day
+    path: req.baseUrl + "/refresh-token", // only the current path can access the refresh cookie
+  });
+}
+
+function generateTokens(userId) {
+  // follow OWASP recommendation
+  // https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html#token-sidejacking
+  const fingerprint = uuidv4();
+  const refresh = uuidv4();
+  const hashedFingerprint = hashToken(fingerprint);
+  const hashedRefresh = hashToken(refresh);
+  const token = jwt.sign(
+    { id: userId, fingerprint: hashedFingerprint, refresh: hashedRefresh },
+    process.env.TOKEN_SECRET,
+    {
+      expiresIn: "15m",
+    }
+  );
+  return { token, fingerprint, refresh };
+}
+
+export { generateTokens, hashToken, setCookies };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios-cache-interceptor": "^1.5.3",
     "bcrypt": "^5.1.1",
     "chai": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "email-validator": "^2.0.4",
@@ -37,6 +38,7 @@
     "sanitize-html": "^2.13.0",
     "sequelize": "^6.37.3",
     "sinon": "^18.0.0",
+    "uuid": "^10.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       chai:
         specifier: ^5.1.1
         version: 5.1.1
+      cookie-parser:
+        specifier: ^1.4.6
+        version: 1.4.6
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -65,6 +68,9 @@ importers:
       sinon:
         specifier: ^18.0.0
         version: 18.0.0
+      uuid:
+        specifier: ^10.0.0
+        version: 10.0.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -400,8 +406,16 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  cookie-parser@1.4.6:
+    resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
+    engines: {node: '>= 0.8.0'}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie@0.4.1:
+    resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -1509,6 +1523,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -1932,7 +1950,14 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  cookie-parser@1.4.6:
+    dependencies:
+      cookie: 0.4.1
+      cookie-signature: 1.0.6
+
   cookie-signature@1.0.6: {}
+
+  cookie@0.4.1: {}
 
   cookie@0.6.0: {}
 
@@ -3039,6 +3064,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
This PR improves security of the website by adding JWT token expiration and a mechanism to refresh it.
A renewed JWT token every X minutes is more secure.

### How
A cookie containing the refresh token is sent to front-end.
This refresh token is used to create a new JWT token.
As explained in [OWASP docs](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html#token-sidejacking), a fingerprint cookie (user context) is added to prevent XSS attack.

A route at `/auth/refresh-token` is created to refresh the token.

⚠️ Therefore, front-end must be updated in the same time :
- https://github.com/simonc56/filmovies-front/pull/2